### PR TITLE
Refactor and animate workspace indicators

### DIFF
--- a/ags/bar/widgets/workspaces.ts
+++ b/ags/bar/widgets/workspaces.ts
@@ -1,3 +1,4 @@
+import type GLib from "gi://GLib";
 import { config } from "lib/settings.js";
 import type { Binding } from "types/service.js";
 import { BarWidget } from "../bar-widget.js";
@@ -27,6 +28,58 @@ export const Workspaces = (monitor: number) =>
             );
           };
 
+          // The workspace that is currently shown as active on the bar.
+          const shown_active_workspace = Variable(1);
+          // The active workspace that the bar should visually be moving towards.
+          let target_active_workspace = 1;
+          // A ticker used to smoothly interpolate the shown_active_workspace to the real active
+          // workspace.
+          let workspace_ticker: null | GLib.Source = null;
+
+          const smooth_active_workspace = Utils.merge(
+            [
+              hyprland.bind("monitors").as((monitors) => monitors[monitor].activeWorkspace.id),
+              shown_active_workspace.bind(),
+            ],
+            (real_active, shown_active) => {
+              target_active_workspace = real_active;
+
+              const step_amount = Math.abs(shown_active - real_active);
+              if (step_amount === 0) {
+                return shown_active;
+              }
+
+              if (workspace_ticker !== null) {
+                clearInterval(workspace_ticker);
+              }
+              workspace_ticker = setInterval(
+                () => {
+                  if (target_active_workspace > shown_active_workspace.value) {
+                    shown_active_workspace.value++;
+                  } else if (target_active_workspace < shown_active_workspace.value) {
+                    shown_active_workspace.value--;
+                  } else {
+                    if (workspace_ticker !== null) {
+                      clearInterval(workspace_ticker);
+                      workspace_ticker = null;
+                    }
+                  }
+                },
+                (50 + Math.min(Math.max(step_amount - 1, 0), 2) * 50) / step_amount,
+              );
+
+              // Display one step ahead of the `snown_active` variable to make the animation more
+              // responsive (play it instantly when workspace is switched).
+              let ret = shown_active;
+              if (target_active_workspace > shown_active_workspace.value) {
+                ret++;
+              } else if (target_active_workspace < shown_active_workspace.value) {
+                ret--;
+              }
+              return ret;
+            },
+          );
+
           self.hook(
             hyprland,
             (self) => {
@@ -35,12 +88,7 @@ export const Workspaces = (monitor: number) =>
 
               for (let i = old_workspace_count; i < new_workspace_count; i++) {
                 self.add(
-                  WorkspaceIndicator(
-                    hyprland
-                      .bind("monitors")
-                      .as((monitors) => monitors[monitor])
-                      .as((monitor) => monitor.activeWorkspace.id === i + 1),
-                  ),
+                  WorkspaceIndicator(smooth_active_workspace.as((active) => active === i + 1)),
                 );
               }
             },

--- a/ags/bar/widgets/workspaces.ts
+++ b/ags/bar/widgets/workspaces.ts
@@ -1,43 +1,65 @@
 import { config } from "lib/settings.js";
+import type { Binding } from "types/service.js";
 import { BarWidget } from "../bar-widget.js";
 
 const hyprland = await Service.import("hyprland");
 
-const WorkspaceIndicator = (active = false) =>
+const WorkspaceIndicator = (active: Binding<any, any, boolean>) =>
   Widget.Box({
-    className: `workspace-indicator${active ? " active" : ""}`,
+    className: active.as((active) => `workspace-indicator${active ? " active" : ""}`),
+    vexpand: false,
+    visible: true,
   });
 
 export const Workspaces = (monitor: number) =>
   BarWidget({
-    child: Widget.Box({
-      className: "workspaces",
-      children: Utils.merge(
-        [
-          hyprland.bind("workspaces"),
-          // TODO: this breaks when unplugging a monitor that is not the last monitor in the list.
-          hyprland
-            .bind("monitors")
-            .as((monitors) => monitors[monitor].activeWorkspace),
-        ],
-        (workspaces, active) => {
-          // Workspaces start with ID 1. It is limited to 25 to keep it reasonable should hyprland
-          // return anything unexpected.
-          const workspaces_num = Math.max(
-            // Always prioritize the value from the config as a minimum amount.
-            config.minWorkspaces,
-            Math.min(25, Math.max(...workspaces.map((workspace) => workspace.id))),
+    child: Widget.CenterBox({
+      centerWidget: Widget.Box({
+        className: "workspaces",
+        setup(self) {
+          const calc_workspace_count = () => {
+            // Workspaces start with ID 1. It is limited to 25 to keep it reasonable should hyprland
+            // return anything unexpected.
+            return Math.max(
+              // Always prioritize the value from the config as a minimum amount.
+              config.minWorkspaces,
+              Math.min(25, Math.max(...hyprland.workspaces.map((workspace) => workspace.id))),
+            );
+          };
+
+          self.hook(
+            hyprland,
+            (self) => {
+              const old_workspace_count = self.children.length;
+              const new_workspace_count = calc_workspace_count();
+
+              for (let i = old_workspace_count; i < new_workspace_count; i++) {
+                self.add(
+                  WorkspaceIndicator(
+                    hyprland
+                      .bind("monitors")
+                      .as((monitors) => monitors[monitor])
+                      .as((monitor) => monitor.activeWorkspace.id === i + 1),
+                  ),
+                );
+              }
+            },
+            "workspace-added",
           );
-          const children = new Array(workspaces_num);
+          self.hook(
+            hyprland,
+            (self) => {
+              const old_workspace_count = self.children.length;
+              const new_workspace_count = calc_workspace_count();
 
-          for (let i = 0; i < workspaces_num; i++) {
-            const id = i + 1;
-            children[i] = WorkspaceIndicator(id === active.id);
-          }
-
-          return children;
+              for (let i = old_workspace_count; i > new_workspace_count; i--) {
+                self.remove(self.children[i - 1]);
+              }
+            },
+            "workspace-removed",
+          );
         },
-      ),
+      }),
     }),
     on_scroll_up: () => {
       hyprland.messageAsync("dispatch workspace +1");

--- a/ags/bar/widgets/workspaces.ts
+++ b/ags/bar/widgets/workspaces.ts
@@ -42,6 +42,12 @@ export const Workspaces = (monitor: number) =>
               shown_active_workspace.bind(),
             ],
             (real_active, shown_active) => {
+              // The simple animation just animates the previous and new active workspace indicators
+              // without touching the other ones.
+              if (config.animations?.activeWorkspace === "simple") {
+                return real_active;
+              }
+
               target_active_workspace = real_active;
 
               const step_amount = Math.abs(shown_active - real_active);

--- a/ags/lib/settings.ts
+++ b/ags/lib/settings.ts
@@ -12,6 +12,9 @@ if (xdg_config_home !== null) {
 
 /** The program configuration. */
 export let config = {
+  animations: {
+    activeWorkspace: opt<"simple" | "smooth">("simple"),
+  },
   minWorkspaces: opt<number>(3),
   lockCommand: opt<string | null>(null),
 };

--- a/ags/style.scss
+++ b/ags/style.scss
@@ -79,8 +79,8 @@
         @include rounded-full;
 
         transition-property: min-width, background-color;
-        transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-        transition-duration: 150ms;
+        transition-timing-function: cubic-bezier(0, 0.55, 0.45, 1);
+        transition-duration: 200ms;
 
         min-height: 0.45em;
         min-width: 0.45em;
@@ -92,7 +92,7 @@
 
         &.active {
           min-height: 0.6em;
-          min-width: 1.75em;
+          min-width: 1.8em;
 
           margin-bottom: -0.30em;
           margin-top: -0.30em;

--- a/ags/style.scss
+++ b/ags/style.scss
@@ -70,23 +70,29 @@
     .workspaces {
       padding-top: 0.870em;
       padding-bottom: 0.870em;
+      padding-left: 0.25em;
+      padding-right: 0.25em;
 
+      @include space-between-x(0.5em);
 
       .workspace-indicator {
         @include rounded-full;
 
-        padding: 0.25em;
+        transition-property: min-width, background-color;
+        transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+        transition-duration: 150ms;
 
-        margin-left: 0.25em;
-        margin-right: 0.25em;
+        min-height: 0.45em;
+        min-width: 0.45em;
+
         margin-bottom: -0.20em;
         margin-top: -0.20em;
 
         background-color: mix($background0, $text, 50%);
 
         &.active {
-          padding: 0.35em;
-          padding-left: 1.4em;
+          min-height: 0.6em;
+          min-width: 1.75em;
 
           margin-bottom: -0.30em;
           margin-top: -0.30em;

--- a/modules/mithril-shell.nix
+++ b/modules/mithril-shell.nix
@@ -65,6 +65,23 @@ in
     };
 
     settings = {
+      animations = {
+        activeWorkspace = mkOption {
+          type = types.enum [
+            "simple"
+            "smooth"
+          ];
+          default = "smooth";
+          example = "simple";
+          description = lib.mdDoc ''
+            The animation to display when changing the active workspace on the current monitor.
+            - **simple:** only animate the old and new active workspace indicators.
+            - **smooth:** run through all intermediate workspace indicators until reaching the new
+              active indicator.
+          '';
+        };
+      };
+
       minWorkspaces = mkOption {
         type = types.int;
         default = 3;


### PR DESCRIPTION
Improves the code and css of the workspace indicators. This also animates them and includes a fancy animation when changing workspaces that are not directly next to eachother. Sadly, the animation is ever so slightly janky due to how it is implemented. I'm not sure how GNOME keeps it perfectly stable.
I may have to add a configuration option to disable the animation between non-neighbour workspaces for those who don't like it.

https://github.com/user-attachments/assets/e741ce94-deb1-490d-8d63-fa3c4b97fcc1

@exellentcoin26 what do you think about the animation?