### PR TITLE
feat: add power menu

### DIFF
--- a/ags/lib/settings.ts
+++ b/ags/lib/settings.ts
@@ -26,6 +26,18 @@ export let config = {
     },
   },
   lockCommand: opt<string | null>(null),
+  powerMenuEntries: opt<Array<{ label: string; command: string; confirmation?: string }>>([
+    {
+      label: "Restart",
+      command: "reboot",
+      confirmation: "Are you sure you want to restart the computer?",
+    },
+    {
+      label: "Power Off",
+      command: "shutdown now",
+      confirmation: "Are you sure you want to power off the computer?",
+    },
+  ]),
   minWorkspaces: opt<number>(3),
   popups: {
     volumePopup: {

--- a/ags/quicksettings/power-menu.ts
+++ b/ags/quicksettings/power-menu.ts
@@ -8,7 +8,6 @@ import { PopupWindow, showModal } from "window";
  *
  * @param reveal - Variable that stores the reveal state of the power menu.
  */
-
 export const PowerMenu = (params: {
   reveal?: Binding<any, any, boolean>;
 }) => {

--- a/ags/quicksettings/power-menu.ts
+++ b/ags/quicksettings/power-menu.ts
@@ -1,0 +1,124 @@
+import type Gtk from "gi://Gtk?version=3.0";
+import { Variable } from "types/variable";
+import { PopupWindow, showModal } from "window";
+
+/**
+ * Power menu that lists multiple power options.
+ *
+ * @param reveal - Variable that stores the reveal state of the power menu.
+ */
+export const PowerMenu = (params: {
+  reveal: Variable<boolean>;
+}) => {
+  return Widget.Revealer({
+    hexpand: false,
+    transition: "slide_down",
+    transitionDuration: 150,
+    revealChild: params.reveal.bind(),
+    child: Widget.Box({
+      className: "power-menu",
+      hexpand: true,
+      vexpand: false,
+      vertical: true,
+      children: [
+        Widget.Box({
+          className: "title",
+          children: [
+            Widget.Icon({
+              className: "icon",
+              icon: "system-shutdown-symbolic",
+              size: 20,
+            }),
+            Widget.Label({
+              label: "Power Off",
+            }),
+          ],
+        }),
+        Widget.Box({
+          className: "entries",
+          vertical: true,
+          children: [
+            Widget.Button({
+              className: "entry",
+              hexpand: true,
+              child: Widget.Box({
+                children: [
+                  Widget.Label({
+                    label: "Restart...",
+                  }),
+                ],
+              }),
+              async onClicked() {
+                App.closeWindow("quicksettings");
+
+                const shutdown = await showModal({
+                  title: "Restart",
+                  description: "Are you sure you want to restart the computer?",
+                  noOption: "Cancel",
+                  yesOption: "Restart",
+                  emphasize: "no",
+                });
+
+                if (shutdown) {
+                  await Utils.execAsync("reboot");
+                }
+              },
+            }),
+            Widget.Button({
+              className: "entry",
+              hexpand: true,
+              child: Widget.Box({
+                children: [
+                  Widget.Label({
+                    label: "Power Off...",
+                  }),
+                ],
+              }),
+              async onClicked() {
+                App.closeWindow("quicksettings");
+
+                const shutdown = await showModal({
+                  title: "Power Off",
+                  description: "Are you sure you want to power off the computer?",
+                  noOption: "Cancel",
+                  yesOption: "Power Off",
+                  emphasize: "no",
+                });
+
+                if (shutdown) {
+                  await Utils.execAsync("shutdown now");
+                }
+              },
+            }),
+            Widget.Button({
+              className: "entry",
+              hexpand: true,
+              child: Widget.Box({
+                children: [
+                  Widget.Label({
+                    label: "Log Out...",
+                  }),
+                ],
+              }),
+              async onClicked() {
+                App.closeWindow("quicksettings");
+
+                const shutdown = await showModal({
+                  title: "Log Out",
+                  description: "Are you sure you want log out of this session?",
+                  noOption: "Cancel",
+                  yesOption: "Log Out",
+                  emphasize: "no",
+                });
+
+                if (shutdown) {
+                  await Utils.execAsync("uwsm stop");
+                }
+              },
+            }),
+          ],
+        }),
+      ],
+    }),
+  });
+};

--- a/ags/quicksettings/power-menu.ts
+++ b/ags/quicksettings/power-menu.ts
@@ -1,6 +1,6 @@
 import type Gtk from "gi://Gtk?version=3.0";
 import { config } from "lib/settings";
-import { Variable } from "types/variable";
+import type { Binding } from "types/service.js";
 import { PopupWindow, showModal } from "window";
 
 /**
@@ -10,7 +10,7 @@ import { PopupWindow, showModal } from "window";
  */
 
 export const PowerMenu = (params: {
-  reveal: Variable<boolean>;
+  reveal?: Binding<any, any, boolean>;
 }) => {
   const entries = config.powerMenuEntries.map(({ label, command, confirmation }) =>
     Widget.Button({
@@ -47,7 +47,7 @@ export const PowerMenu = (params: {
     hexpand: false,
     transition: "slide_down",
     transitionDuration: 150,
-    revealChild: params.reveal.bind(),
+    revealChild: params.reveal,
     child: Widget.Box({
       className: "power-menu",
       hexpand: true,

--- a/ags/quicksettings/quicksettings.ts
+++ b/ags/quicksettings/quicksettings.ts
@@ -147,91 +147,115 @@ export const Quicksettings = () => {
 };
 
 const PowerMenu = () => {
-  return Widget.Box({
-    className: "power-menu",
-    visible: powerMenuVisible.bind(),
-    hexpand: true,
-    vexpand: false,
-    vertical: true,
-    children: [
-      Widget.Button({
-        className: "entry",
-        hexpand: true,
-        child: Widget.Box({
+  return Widget.Revealer({
+    hexpand: false,
+    transition: "slide_down",
+    transitionDuration: 150,
+    revealChild: powerMenuVisible.bind(),
+    child: Widget.Box({
+      className: "power-menu",
+      hexpand: true,
+      vexpand: false,
+      vertical: true,
+      children: [
+        Widget.Box({
+          className: "title",
           children: [
+            Widget.Icon({
+              className: "icon",
+              icon: "system-shutdown-symbolic",
+              size: 20,
+            }),
             Widget.Label({
-              label: "Restart...",
+              label: "Power Off",
             }),
           ],
         }),
-        async onClicked() {
-          App.closeWindow("quicksettings");
-
-          const shutdown = await showModal({
-            title: "Restart",
-            description: "Are you sure you want to restart the computer?",
-            noOption: "Cancel",
-            yesOption: "Restart",
-            emphasize: "no",
-          });
-
-          if (shutdown) {
-            await Utils.execAsync("reboot");
-          }
-        },
-      }),
-      Widget.Button({
-        className: "entry",
-        hexpand: true,
-        child: Widget.Box({
+        Widget.Box({
+          className: "entries",
+          vertical: true,
           children: [
-            Widget.Label({
-              label: "Power Off...",
+            Widget.Button({
+              className: "entry",
+              hexpand: true,
+              child: Widget.Box({
+                children: [
+                  Widget.Label({
+                    label: "Restart...",
+                  }),
+                ],
+              }),
+              async onClicked() {
+                App.closeWindow("quicksettings");
+
+                const shutdown = await showModal({
+                  title: "Restart",
+                  description: "Are you sure you want to restart the computer?",
+                  noOption: "Cancel",
+                  yesOption: "Restart",
+                  emphasize: "no",
+                });
+
+                if (shutdown) {
+                  await Utils.execAsync("reboot");
+                }
+              },
+            }),
+            Widget.Button({
+              className: "entry",
+              hexpand: true,
+              child: Widget.Box({
+                children: [
+                  Widget.Label({
+                    label: "Power Off...",
+                  }),
+                ],
+              }),
+              async onClicked() {
+                App.closeWindow("quicksettings");
+
+                const shutdown = await showModal({
+                  title: "Power Off",
+                  description: "Are you sure you want to power off the computer?",
+                  noOption: "Cancel",
+                  yesOption: "Power Off",
+                  emphasize: "no",
+                });
+
+                if (shutdown) {
+                  await Utils.execAsync("shutdown now");
+                }
+              },
+            }),
+            Widget.Button({
+              className: "entry",
+              hexpand: true,
+              child: Widget.Box({
+                children: [
+                  Widget.Label({
+                    label: "Log Out...",
+                  }),
+                ],
+              }),
+              async onClicked() {
+                App.closeWindow("quicksettings");
+
+                const shutdown = await showModal({
+                  title: "Log Out",
+                  description: "Are you sure you want log out of this session?",
+                  noOption: "Cancel",
+                  yesOption: "Log Out",
+                  emphasize: "no",
+                });
+
+                if (shutdown) {
+                  await Utils.execAsync("uwsm stop");
+                }
+              },
             }),
           ],
         }),
-        async onClicked() {
-          App.closeWindow("quicksettings");
-
-          const shutdown = await showModal({
-            title: "Power Off",
-            description: "Are you sure you want to power off the computer?",
-            noOption: "Cancel",
-            yesOption: "Power Off",
-            emphasize: "no",
-          });
-
-          if (shutdown) {
-            await Utils.execAsync("shutdown now");
-          }
-        },
-      }),
-      Widget.Button({
-        className: "entry",
-        hexpand: true,
-        child: Widget.Box({
-          children: [
-            Widget.Label({
-              label: "Log Out...",
-            }),
-          ],
-        }),
-        async onClicked() {
-          App.closeWindow("quicksettings");
-
-          const shutdown = await showModal({
-            title: "Log Out",
-            description: "Are you sure you want log out of this session?",
-            noOption: "Cancel",
-            yesOption: "Log Out",
-            emphasize: "no",
-          });
-
-          if (shutdown) {
-            await Utils.execAsync("uwsm stop");
-          }
-        },
-      }),
-    ],
+      ],
+    }),
   });
 };

--- a/ags/quicksettings/quicksettings.ts
+++ b/ags/quicksettings/quicksettings.ts
@@ -7,6 +7,7 @@ import { Toggles } from "./toggles";
 
 const battery = await Service.import("battery");
 const hyprland = await Service.import("hyprland");
+const powerMenuVisible = Variable(false);
 
 /** Constructor for the top buttons in the quicksettings menu. */
 const Button = (props: {
@@ -96,19 +97,7 @@ export const Quicksettings = () => {
     Button({
       icon: "system-shutdown-symbolic",
       async onClick() {
-        App.closeWindow("quicksettings");
-
-        const shutdown = await showModal({
-          title: "Power Off",
-          description: "Are you sure you want to power off the computer?",
-          noOption: "Cancel",
-          yesOption: "Power Off",
-          emphasize: "no",
-        });
-
-        if (shutdown) {
-          await Utils.execAsync("shutdown now");
-        }
+        powerMenuVisible.value = !powerMenuVisible.value;
       },
     }),
   ];
@@ -138,10 +127,111 @@ export const Quicksettings = () => {
           }),
         }),
 
+        PowerMenu(),
+
         Sliders(),
 
         Toggles(),
       ],
     }),
+    setup(self) {
+      self.hook(
+        App,
+        () => {
+          powerMenuVisible.value = false;
+        },
+        "window-toggled",
+      );
+    },
+  });
+};
+
+const PowerMenu = () => {
+  return Widget.Box({
+    className: "power-menu",
+    visible: powerMenuVisible.bind(),
+    hexpand: true,
+    vexpand: false,
+    vertical: true,
+    children: [
+      Widget.Button({
+        className: "entry",
+        hexpand: true,
+        child: Widget.Box({
+          children: [
+            Widget.Label({
+              label: "Restart...",
+            }),
+          ],
+        }),
+        async onClicked() {
+          App.closeWindow("quicksettings");
+
+          const shutdown = await showModal({
+            title: "Restart",
+            description: "Are you sure you want to restart the computer?",
+            noOption: "Cancel",
+            yesOption: "Restart",
+            emphasize: "no",
+          });
+
+          if (shutdown) {
+            await Utils.execAsync("reboot");
+          }
+        },
+      }),
+      Widget.Button({
+        className: "entry",
+        hexpand: true,
+        child: Widget.Box({
+          children: [
+            Widget.Label({
+              label: "Power Off...",
+            }),
+          ],
+        }),
+        async onClicked() {
+          App.closeWindow("quicksettings");
+
+          const shutdown = await showModal({
+            title: "Power Off",
+            description: "Are you sure you want to power off the computer?",
+            noOption: "Cancel",
+            yesOption: "Power Off",
+            emphasize: "no",
+          });
+
+          if (shutdown) {
+            await Utils.execAsync("shutdown now");
+          }
+        },
+      }),
+      Widget.Button({
+        className: "entry",
+        hexpand: true,
+        child: Widget.Box({
+          children: [
+            Widget.Label({
+              label: "Log Out...",
+            }),
+          ],
+        }),
+        async onClicked() {
+          App.closeWindow("quicksettings");
+
+          const shutdown = await showModal({
+            title: "Log Out",
+            description: "Are you sure you want log out of this session?",
+            noOption: "Cancel",
+            yesOption: "Log Out",
+            emphasize: "no",
+          });
+
+          if (shutdown) {
+            await Utils.execAsync("uwsm stop");
+          }
+        },
+      }),
+    ],
   });
 };

--- a/ags/quicksettings/quicksettings.ts
+++ b/ags/quicksettings/quicksettings.ts
@@ -2,9 +2,9 @@ import { config } from "lib/settings";
 import type { Icon } from "lib/types";
 import type { Binding } from "types/service";
 import { PopupWindow, showModal } from "window";
+import { PowerMenu } from "./power-menu";
 import { Sliders } from "./sliders";
 import { Toggles } from "./toggles";
-import { PowerMenu } from "./power-menu";
 
 const battery = await Service.import("battery");
 const hyprland = await Service.import("hyprland");

--- a/ags/quicksettings/quicksettings.ts
+++ b/ags/quicksettings/quicksettings.ts
@@ -8,7 +8,6 @@ import { PowerMenu } from "./power-menu";
 
 const battery = await Service.import("battery");
 const hyprland = await Service.import("hyprland");
-const powerMenuReveal = Variable(false);
 
 /** Constructor for the top buttons in the quicksettings menu. */
 const Button = (props: {
@@ -42,6 +41,7 @@ const Button = (props: {
 export const Quicksettings = () => {
   // Used to take a screenshot without including the quicksettings menu.
   const opacity = Variable(1.0);
+  const revealPowerMenu = Variable(false);
 
   const top_button_battery = Button({
     icon: battery.bind("icon_name"),
@@ -98,12 +98,12 @@ export const Quicksettings = () => {
     Button({
       icon: "system-shutdown-symbolic",
       async onClick() {
-        powerMenuReveal.value = !powerMenuReveal.value;
+        revealPowerMenu.value = !revealPowerMenu.value;
       },
     }),
   ];
 
-  return PopupWindow({
+  const window = PopupWindow({
     name: "quicksettings",
     location: "top-right",
     child: Widget.Box({
@@ -128,21 +128,22 @@ export const Quicksettings = () => {
           }),
         }),
 
-        PowerMenu({ reveal: powerMenuReveal }),
+        PowerMenu({ reveal: revealPowerMenu.bind() }),
 
         Sliders(),
 
         Toggles(),
       ],
     }),
-    setup(self) {
-      self.hook(
-        App,
-        () => {
-          powerMenuReveal.value = false;
-        },
-        "window-toggled",
-      );
-    },
   });
+
+  window.hook(
+    App,
+    () => {
+      revealPowerMenu.value = false;
+    },
+    "window-toggled",
+  );
+
+  return window;
 };

--- a/ags/quicksettings/quicksettings.ts
+++ b/ags/quicksettings/quicksettings.ts
@@ -4,10 +4,11 @@ import type { Binding } from "types/service";
 import { PopupWindow, showModal } from "window";
 import { Sliders } from "./sliders";
 import { Toggles } from "./toggles";
+import { PowerMenu } from "./power-menu";
 
 const battery = await Service.import("battery");
 const hyprland = await Service.import("hyprland");
-const powerMenuVisible = Variable(false);
+const powerMenuReveal = Variable(false);
 
 /** Constructor for the top buttons in the quicksettings menu. */
 const Button = (props: {
@@ -97,7 +98,7 @@ export const Quicksettings = () => {
     Button({
       icon: "system-shutdown-symbolic",
       async onClick() {
-        powerMenuVisible.value = !powerMenuVisible.value;
+        powerMenuReveal.value = !powerMenuReveal.value;
       },
     }),
   ];
@@ -127,7 +128,7 @@ export const Quicksettings = () => {
           }),
         }),
 
-        PowerMenu(),
+        PowerMenu({ reveal: powerMenuReveal }),
 
         Sliders(),
 
@@ -138,124 +139,10 @@ export const Quicksettings = () => {
       self.hook(
         App,
         () => {
-          powerMenuVisible.value = false;
+          powerMenuReveal.value = false;
         },
         "window-toggled",
       );
     },
-  });
-};
-
-const PowerMenu = () => {
-  return Widget.Revealer({
-    hexpand: false,
-    transition: "slide_down",
-    transitionDuration: 150,
-    revealChild: powerMenuVisible.bind(),
-    child: Widget.Box({
-      className: "power-menu",
-      hexpand: true,
-      vexpand: false,
-      vertical: true,
-      children: [
-        Widget.Box({
-          className: "title",
-          children: [
-            Widget.Icon({
-              className: "icon",
-              icon: "system-shutdown-symbolic",
-              size: 20,
-            }),
-            Widget.Label({
-              label: "Power Off",
-            }),
-          ],
-        }),
-        Widget.Box({
-          className: "entries",
-          vertical: true,
-          children: [
-            Widget.Button({
-              className: "entry",
-              hexpand: true,
-              child: Widget.Box({
-                children: [
-                  Widget.Label({
-                    label: "Restart...",
-                  }),
-                ],
-              }),
-              async onClicked() {
-                App.closeWindow("quicksettings");
-
-                const shutdown = await showModal({
-                  title: "Restart",
-                  description: "Are you sure you want to restart the computer?",
-                  noOption: "Cancel",
-                  yesOption: "Restart",
-                  emphasize: "no",
-                });
-
-                if (shutdown) {
-                  await Utils.execAsync("reboot");
-                }
-              },
-            }),
-            Widget.Button({
-              className: "entry",
-              hexpand: true,
-              child: Widget.Box({
-                children: [
-                  Widget.Label({
-                    label: "Power Off...",
-                  }),
-                ],
-              }),
-              async onClicked() {
-                App.closeWindow("quicksettings");
-
-                const shutdown = await showModal({
-                  title: "Power Off",
-                  description: "Are you sure you want to power off the computer?",
-                  noOption: "Cancel",
-                  yesOption: "Power Off",
-                  emphasize: "no",
-                });
-
-                if (shutdown) {
-                  await Utils.execAsync("shutdown now");
-                }
-              },
-            }),
-            Widget.Button({
-              className: "entry",
-              hexpand: true,
-              child: Widget.Box({
-                children: [
-                  Widget.Label({
-                    label: "Log Out...",
-                  }),
-                ],
-              }),
-              async onClicked() {
-                App.closeWindow("quicksettings");
-
-                const shutdown = await showModal({
-                  title: "Log Out",
-                  description: "Are you sure you want log out of this session?",
-                  noOption: "Cancel",
-                  yesOption: "Log Out",
-                  emphasize: "no",
-                });
-
-                if (shutdown) {
-                  await Utils.execAsync("uwsm stop");
-                }
-              },
-            }),
-          ],
-        }),
-      ],
-    }),
   });
 };

--- a/ags/style.scss
+++ b/ags/style.scss
@@ -200,11 +200,6 @@ window.darkened {
   margin-left: 0.5em;
   margin-bottom: 0.5em;
 
-  label {
-    font-weight: bold;
-    font-size: 14px;
-  }
-
   .button-row {
     @include space-between-x(3em);
 
@@ -228,6 +223,29 @@ window.darkened {
 
       * {
         color: $background1;
+      }
+    }
+  }
+
+  .power-menu {
+    border-radius: 15px;
+    background-color: $background1;
+
+    .entry {
+      @include rounded-full;
+      padding: 0.625em;
+      padding-left: 1.3em;
+
+      &:hover {
+        background-color: hover-color($surface0);
+      }
+
+      &:active {
+        background-color: $primary;
+
+        * {
+          color: $background1;
+        }
       }
     }
   }
@@ -271,6 +289,11 @@ window.darkened {
   }
 
   .toggle-buttons {
+    label {
+      font-weight: bold;
+      font-size: 14px;
+    }
+
     .toggle-button {
       border-top-left-radius: 9999px;
       border-bottom-left-radius: 9999px;

--- a/ags/style.scss
+++ b/ags/style.scss
@@ -228,23 +228,42 @@ window.darkened {
   }
 
   .power-menu {
-    border-radius: 15px;
-    background-color: $background1;
+    @include space-between-y(0.625em);
 
-    .entry {
-      @include rounded-full;
-      padding: 0.625em;
-      padding-left: 1.3em;
+    margin-top: 1.5em;
+    padding: 0.625em;
+    border-radius: 25px;
+    background-color: hover-color($background1);
 
-      &:hover {
+    .title {
+      .icon {
+        @include rounded-full;
+        padding: 0.625em;
         background-color: hover-color($surface0);
+        margin-right: 0.625em;
       }
 
-      &:active {
-        background-color: $primary;
+      label {
+        font-size: 1.5em;
+        font-weight: bold;
+      }
+    }
 
-        * {
-          color: $background1;
+    .entries {
+      .entry {
+        @include rounded-full;
+        padding: 0.625em;
+
+        &:hover {
+          background-color: hover-color($surface0);
+        }
+
+        &:active {
+          background-color: $primary;
+
+          * {
+            color: $background1;
+          }
         }
       }
     }

--- a/ags/style.scss
+++ b/ags/style.scss
@@ -230,7 +230,7 @@ window.darkened {
   .power-menu {
     @include space-between-y(0.625em);
 
-    margin-top: 1.5em;
+    margin-top: 1.25em;
     padding: 0.625em;
     border-radius: 25px;
     background-color: hover-color($background1);
@@ -244,7 +244,7 @@ window.darkened {
       }
 
       label {
-        font-size: 1.5em;
+        font-size: 1.25em;
         font-weight: bold;
       }
     }

--- a/ags/window.ts
+++ b/ags/window.ts
@@ -38,7 +38,6 @@ export const PopupWindow = (props: {
   windowStyle?: string;
   windowLayer?: WindowProps["layer"];
   exclusivity?: WindowProps["exclusivity"];
-  setup?: (self: PopupWindow) => void;
 }) => {
   const clickoff = props.clickoff ?? true;
 
@@ -57,7 +56,6 @@ export const PopupWindow = (props: {
     keymode: "on-demand",
     setup: (self) => {
       self.keybind("Escape", () => App.closeWindow("quicksettings"));
-      props.setup?.(self);
     },
     child: Widget.Box({
       children: conditionalChildren([

--- a/ags/window.ts
+++ b/ags/window.ts
@@ -38,6 +38,7 @@ export const PopupWindow = (props: {
   windowStyle?: string;
   windowLayer?: WindowProps["layer"];
   exclusivity?: WindowProps["exclusivity"];
+  setup?: (self: PopupWindow) => void;
 }) => {
   const clickoff = props.clickoff ?? true;
 
@@ -56,6 +57,7 @@ export const PopupWindow = (props: {
     keymode: "on-demand",
     setup: (self) => {
       self.keybind("Escape", () => App.closeWindow("quicksettings"));
+      props.setup?.(self);
     },
     child: Widget.Box({
       children: conditionalChildren([

--- a/modules/mithril-shell.nix
+++ b/modules/mithril-shell.nix
@@ -110,6 +110,50 @@ in
         '';
       };
 
+      powerMenuEntries = mkOption {
+        type = types.listOf (types.submodule {
+          options = {
+            label = mkOption {
+              type = types.str;
+              example = "Power Off";
+              description = ''
+                The name of the power menu entry.
+              '';
+            };
+            command = mkOption {
+              type = types.str;
+              example = "shutdown now";
+              description = ''
+                The command to run when selecting the option.
+              '';
+            };
+            confirmation = mkOption {
+              type = types.nullOr types.str;
+              default = null;
+              example = "Are you sure you want to power off the computer?";
+              description = ''
+                An optional confirmation prompt to show before running the command.
+              '';
+            };
+          };
+        });
+        description = ''
+          List of entries to show in the power menu.
+        '';
+        default = [
+          {
+            label = "Restart";
+            command = "reboot";
+            confirmation = "Are you sure you want to restart the computer?";
+          }
+          {
+            label = "Power Off";
+            command = "shutdown now";
+            confirmation = "Are you sure you want to power off the computer?";
+          }
+        ];
+      };
+
       minWorkspaces = mkOption {
         type = types.int;
         default = 3;

--- a/modules/mithril-shell.nix
+++ b/modules/mithril-shell.nix
@@ -111,32 +111,34 @@ in
       };
 
       powerMenuEntries = mkOption {
-        type = types.listOf (types.submodule {
-          options = {
-            label = mkOption {
-              type = types.str;
-              example = "Power Off";
-              description = ''
-                The name of the power menu entry.
-              '';
+        type = types.listOf (
+          types.submodule {
+            options = {
+              label = mkOption {
+                type = types.str;
+                example = "Power Off";
+                description = ''
+                  The name of the power menu entry.
+                '';
+              };
+              command = mkOption {
+                type = types.str;
+                example = "shutdown now";
+                description = ''
+                  The command to run when selecting the option.
+                '';
+              };
+              confirmation = mkOption {
+                type = types.nullOr types.str;
+                default = null;
+                example = "Are you sure you want to power off the computer?";
+                description = ''
+                  An optional confirmation prompt to show before running the command.
+                '';
+              };
             };
-            command = mkOption {
-              type = types.str;
-              example = "shutdown now";
-              description = ''
-                The command to run when selecting the option.
-              '';
-            };
-            confirmation = mkOption {
-              type = types.nullOr types.str;
-              default = null;
-              example = "Are you sure you want to power off the computer?";
-              description = ''
-                An optional confirmation prompt to show before running the command.
-              '';
-            };
-          };
-        });
+          }
+        );
         description = ''
           List of entries to show in the power menu.
         '';


### PR DESCRIPTION
Adds a power menu with configurable entries. Repurposes the previous power button. Lets you reboot and power off by default. Other options are not available by default because they have dependencies like systemctl or uwsm.

The entries are configurable via the `settings.json` or similarily in Nix:
```json
{
  "powerMenuEntries": [
    {
      "label": "Restart",
      "command": "reboot",
      "confirmation": "Are you sure you want to restart the computer?"
    },
    {
      "label": "Power Off",
      "command": "shutdown now",
      "confirmation":"Are you sure you want to power off the computer?"
    }
  ]
}
```

<img width="442" height="595" alt="image" src="https://github.com/user-attachments/assets/5ee6d62e-ef52-40c0-9521-ff2775f8d4d9" />

Here's also a list of useful commands when configuring these entries:

| command | usecase |
| - | - |
| `systemctl suspend` | Suspend using SystemD |
| `systemctl reboot` | Restart using SystemD |
| `systemctl reboot --firmware-setup` | Restart to UEFI using SystemD |
| `systemctl poweroff`  | Power off using SystemD |
| `uwsm stop` | Log out using UWSM |
| `hyprctl dispatch exit` | Log out of Hyprland without UWSM |
