### PR TITLE
fix: update fixup phase for control-center

### DIFF
--- a/pkgs/mithril-control-center/default.nix
+++ b/pkgs/mithril-control-center/default.nix
@@ -7,11 +7,13 @@ gnome-control-center.overrideAttrs (old: {
 
   patches = old.patches ++ (readPatches ./.);
 
-  postFixup = ''
+  preFixup = ''
     for i in $out/share/applications/*; do
-      substituteInPlace $i --replace "Exec=$out/bin/gnome-control-center" "Exec=$out/bin/mithril-control-center"
+      substituteInPlace $i --replace-warn "Exec=gnome-control-center" "Exec=mithril-control-center"
     done
     mv $out/bin/gnome-control-center $out/bin/mithril-control-center
+
+    ${old.preFixup}
   '';
 
   doCheck = false;


### PR DESCRIPTION
Fixes a build failure caused by the recently introduced noBrokenSymlinks derivation check. The binary is now already being renamed in the preFixup phase so the correct path can be symlinked by the separateDebugInfo script.

Also fixes the substitution inside of desktop files which seems to have been broken by an upstream update.

Fixes the following error:

```
ERROR: noBrokenSymlinks: the symlink /nix/store/krhrf4wnfgnzcsbh42gj12v2p3bdz2l8-mithril-control-center-48.3-debug/lib/debug/.build-id/75/050dd846f74721f88d6d1282326f0a7376a3dc.executable points to
  a missing target: /nix/store/awcgmvcjvbsmhvgqqw2amz4hv234pyx9-mithril-control-center-48.3/bin/gnome-control-center
ERROR: noBrokenSymlinks: found 1 dangling symlinks, 0 reflexive symlinks and 0 unreadable symlinks
```